### PR TITLE
Bug fixes sendMessageDraft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+# **4.13.1 - (2026-01-14)**
+
+## **Bug Fixes**
+
+- **BaseClient:** correct method `sendMessageDraft` ([df555ec](https://github.com/telegramsjs/Telegramsjs/commit/df555ec5f55dd55e009f3de9bcc10036a781f7ca))
+
+---
+
 # **4.13.0 - (2026-01-02)**
 
 ## **Updates**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "telegramsjs",
   "description": "A powerful library for interacting with the Telegram Bot API",
-  "version": "4.13.0",
+  "version": "4.13.1",
   "main": "./dist/src/index.js",
   "types": "./typings/index.d.ts",
   "scripts": {

--- a/src/client/BaseClient.ts
+++ b/src/client/BaseClient.ts
@@ -357,7 +357,7 @@ class BaseClient extends EventEmitter {
     params: MethodParameters["sendMessageDraft"],
   ): Promise<MethodsLibReturnType["sendMessageDraft"]> {
     return this.rest.request<MethodsApiReturnType["sendMessageDraft"]>(
-      "sendMessage",
+      "sendMessageDraft",
       toSnakeCase(params),
     );
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -13392,6 +13392,6 @@ export declare class StarTransactions {
   [Symbol.iterator](): IterableIterator<StarTransaction>;
 }
 
-export declare const version: "4.13.0";
+export declare const version: "4.13.1";
 
 export * from "./telegram/index";


### PR DESCRIPTION
# **4.13.1 - (2026-01-14)**

## **Bug Fixes**

- **BaseClient:** correct method `sendMessageDraft` ([df555ec](https://github.com/telegramsjs/Telegramsjs/commit/df555ec5f55dd55e009f3de9bcc10036a781f7ca))