### PR TITLE
Add support for member tags and date_time entities and extend permission flags

### DIFF
--- a/src/client/BaseClient.ts
+++ b/src/client/BaseClient.ts
@@ -755,6 +755,16 @@ class BaseClient extends EventEmitter {
     >("setChatAdministratorCustomTitle", toSnakeCase(params));
   }
 
+  /** Use this method to set a custom tag for a member of a supergroup. Returns True on success. */
+  async setChatMemberTag(
+    params: MethodParameters["setChatMemberTag"],
+  ): Promise<MethodsLibReturnType["setChatMemberTag"]> {
+    return this.rest.request<true>(
+      "setChatMemberTag",
+      toSnakeCase(params),
+    );
+  }
+
   /** Use this method to ban a channel chat in a supergroup or a channel. Until the chat is unbanned, the owner of the banned chat won't be able to send messages on behalf of any of their channels. The bot must be an administrator in the supergroup or channel for this to work and must have the appropriate administrator rights. Returns True on success. */
   async banChatSenderChat(
     chatId: number | string,

--- a/src/client/interfaces/Message.ts
+++ b/src/client/interfaces/Message.ts
@@ -13,7 +13,7 @@ export interface User {
   /** User's or bot's username */
   username?: string;
   /** IETF language tag of the user's language */
-  language_code?: LanguageCode;
+  language_code?: string;
   /** True, if this user is a Telegram Premium user */
   is_premium?: true;
   /** True, if this user added the bot to the attachment menu */
@@ -36,7 +36,7 @@ export interface LinkPreviewOptions {
 
 export declare namespace MessageEntity {
   interface AbstractMessageEntity {
-    /** Type of the entity. Currently, can be “mention” (@username), “hashtag” (#hashtag), “cashtag” ($USD), “bot_command” (/start@jobs_bot), “url” (https://telegram.org), “email” (do-not-reply@telegram.org), “phone_number” (+1-212-555-0123), “bold” (bold text), “italic” (italic text), “underline” (underlined text), “strikethrough” (strikethrough text), “spoiler” (spoiler message), “blockquote” (block quotation), “expandable_blockquote” (collapsed-by-default block quotation), “code” (monowidth string), “pre” (monowidth block), “text_link” (for clickable text URLs), “text_mention” (for users without usernames), “custom_emoji” (for inline custom emoji stickers) */
+    /** Type of the entity. Currently, can be “mention” (@username), “hashtag” (#hashtag), “cashtag” ($USD), “bot_command” (/start@jobs_bot), “url” (https://telegram.org), “email” (do-not-reply@telegram.org), “phone_number” (+1-212-555-0123), “bold” (bold text), “italic” (italic text), “underline” (underlined text), “strikethrough” (strikethrough text), “spoiler” (spoiler message), “blockquote” (block quotation), “expandable_blockquote” (collapsed-by-default block quotation), “code” (monowidth string), “pre” (monowidth block), “text_link” (for clickable text URLs), “text_mention” (for users without usernames), “custom_emoji” (for inline custom emoji stickers), “date_time” (for a formatted date and time) */
     type: string;
     /** Offset in UTF-16 code units to the start of the entity */
     offset: number;
@@ -59,7 +59,8 @@ export declare namespace MessageEntity {
       | "spoiler"
       | "blockquote"
       | "expandable_blockquote"
-      | "code";
+      | "code"
+      | "date_time";
   }
   export interface PreMessageEntity extends AbstractMessageEntity {
     type: "pre";

--- a/src/client/interfaces/Methods.ts
+++ b/src/client/interfaces/Methods.ts
@@ -1195,6 +1195,16 @@ export type ApiMethods = {
     customTitle: string;
   }): true;
 
+  /** Use this method to set a custom tag for a member of a supergroup. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Returns True on success. */
+  setChatMemberTag(args: {
+    /** Unique identifier for the target supergroup (in the format @supergroupusername) */
+    chatId: number | string;
+    /** Unique identifier of the target user */
+    userId: string | number;
+    /** New tag for the member; 0-32 characters */
+    tag?: string;
+  }): true;
+
   /** Use this method to ban a channel chat in a supergroup or a channel. Until the chat is unbanned, the owner of the banned chat won't be able to send messages on behalf of any of their channels. The bot must be an administrator in the supergroup or channel for this to work and must have the appropriate administrator rights. Returns True on success. */
   banChatSenderChat(args: {
     /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */

--- a/src/structures/chat/ChatAdministratorRights.js
+++ b/src/structures/chat/ChatAdministratorRights.js
@@ -47,6 +47,10 @@ class ChatAdministratorRights {
       permissions.manageTopics = data.can_manage_topics;
     }
 
+    if ("can_manage_tags" in data) {
+      permissions.manageTags = Boolean(data.can_manage_tags);
+    }
+
     /** Represents the rights of an administrator in a chat */
     this.permissions = new ChatPermissions(permissions);
   }

--- a/src/structures/chat/ChatMember.js
+++ b/src/structures/chat/ChatMember.js
@@ -87,6 +87,10 @@ class ChatMember extends Base {
       permissions.manageTopics = data.can_manage_topics;
     }
 
+    if ("can_manage_tags" in data) {
+      permissions.manageTags = Boolean(data.can_manage_tags);
+    }
+
     if ("can_send_messages" in data) {
       permissions.sendMessages = data.can_send_messages;
     }
@@ -127,6 +131,10 @@ class ChatMember extends Base {
       permissions.addWebPagePreviews = data.can_add_web_page_previews;
     }
 
+    if ("can_edit_tag" in data) {
+      permissions.editTag = Boolean(data.can_edit_tag);
+    }
+
     /** Represents the rights of an administrator in a chat */
     this.permissions = new UserPermissions(
       this.status === "creator" ? UserPermissions.Flags : permissions,
@@ -160,6 +168,14 @@ class ChatMember extends Base {
        * @type {string | undefined}
        */
       this.nickName = data.custom_title;
+    }
+
+    if ("tag" in data) {
+      /**
+       * Custom tag for this member
+       * @type {string | undefined}
+       */
+      this.tag = typeof data.tag === "string" ? data.tag : undefined;
     }
 
     if ("is_member" in data) {
@@ -336,6 +352,23 @@ class ChatMember extends Base {
   }
 
   /**
+   * Use this method to set a custom tag for a member of a supergroup.
+   * @param {string} [tag] - New tag for the member; 0-32 characters
+   * @returns {Promise<true>} - Returns True on success.
+   */
+  setTag(tag) {
+    if (!this.id) {
+      throw new TelegramError(ErrorCodes.UserIdNotAvailable);
+    }
+
+    return this.client.setChatMemberTag({
+      chatId: this.chatId,
+      userId: this.id,
+      ...(tag !== undefined && { tag }),
+    });
+  }
+
+  /**
    * Checks if this member is equal to another member.
    * @param {ChatMember} other - The other object to compare with.
    * @returns {boolean} True if both objects are instances of ChatMember and are equal based on key properties, otherwise false.
@@ -353,6 +386,7 @@ class ChatMember extends Base {
       this.user.equals(other.user) &&
       this.anonymous === other.anonymous &&
       this.nickName === other.nickName &&
+      this.tag === other.tag &&
       this.isMember === other.isMember &&
       this.untilUnixTime === other.untilUnixTime
     );

--- a/src/structures/message/Message.js
+++ b/src/structures/message/Message.js
@@ -221,6 +221,15 @@ class Message extends Base {
       this.senderBusinessBot = this.client.users._add(data.sender_business_bot);
     }
 
+    if ("sender_tag" in data) {
+      /**
+       * For messages in channels and replies to channel messages in supergroups, the tag of the message sender
+       * @type {string | undefined}
+       */
+      this.senderTag =
+        typeof data.sender_tag === "string" ? data.sender_tag : undefined;
+    }
+
     if ("forward_origin" in data) {
       /**
        * Information about the original message for forwarded messages

--- a/src/structures/message/MessageEntities.js
+++ b/src/structures/message/MessageEntities.js
@@ -187,8 +187,16 @@ class MessageEntities extends Base {
   }
 
   /**
+   * Retrieves all date_time entities from the message.
+   * @returns {import("@telegram.ts/collection").ReadonlyCollection<number, SearchResult>} A collection of date_time entities.
+   */
+  get dateTime() {
+    return this.searchEntity("date_time");
+  }
+
+  /**
    * Searches for a specific type of entity in the message.
-   * @param {"mention" | "hashtag" | "cashtag" | "bot_command" | "url" | "email" | "phone_number" | "bold" | "italic" | "underline" | "strikethrough" | "spoiler" | "blockquote" | "code" | "pre" | "text_link" | "text_mention" | "custom_emoji"} searchType - The type of entity to search for.
+   * @param {"mention" | "hashtag" | "cashtag" | "bot_command" | "url" | "email" | "phone_number" | "bold" | "italic" | "underline" | "strikethrough" | "spoiler" | "blockquote" | "code" | "pre" | "text_link" | "text_mention" | "custom_emoji" | "date_time"} searchType - The type of entity to search for.
    * @returns {import("@telegram.ts/collection").ReadonlyCollection<number, SearchResult & ({ language?: import("../../client/interfaces/Language").LanguageCode } | { url: string } | { user: User } | { customEmojiId: string })>} A collection of found entities.
    */
   searchEntity(searchType) {
@@ -218,7 +226,7 @@ class MessageEntities extends Base {
   /**
    * Enables iteration over the message entities.
    * @returns {Generator<(SearchResult & ({ type: "mention" | "hashtag" | "cashtag" | "botCommand" | "url" | "email" |
-      "phoneNumber" | "bold" | "italic" | "underline" | "strikethrough" | "spoiler" | "blockquote" | "code" | { type: "pre", language?: import("../../client/interfaces/Language").LanguageCode } | { type: "text_link", url: string } | { type: "text_mention", user: User } | { type: "customEmoji", customEmojiId: string }}))>} An iterator over the message entities.
+      "phoneNumber" | "bold" | "italic" | "underline" | "strikethrough" | "spoiler" | "blockquote" | "code" | "dateTime" | { type: "pre", language?: import("../../client/interfaces/Language").LanguageCode } | { type: "text_link", url: string } | { type: "text_mention", user: User } | { type: "customEmoji", customEmojiId: string }}))>} An iterator over the message entities.
    */
   *[Symbol.iterator]() {
     /** @type {(keyof MessageEntities)[]} */
@@ -241,6 +249,7 @@ class MessageEntities extends Base {
       "textLink",
       "textMention",
       "customEmoji",
+      "dateTime",
     ];
 
     const allEntities = new Collection();

--- a/src/structures/message/MessageOrigin.js
+++ b/src/structures/message/MessageOrigin.js
@@ -310,7 +310,7 @@ class MessageOrigin extends Base {
   /**
    * Use this method to edit a checklist on behalf of a connected business account.
    * @param {string} businessConnectionId - Unique identifier of the business connection on behalf of which the message will be sent.
-   * @param {import("@telegram.ts/types").InputChecklist} checklist - An object for the new checklist.
+   * @param {import("../../client/interfaces/Checklist").InputChecklist} checklist - An object for the new checklist.
    * @param {Omit<MethodParameters["editMessageChecklist"], "messageId" | "chatId" | "checklist" | "businessConnectionId">} [options] - out parameters.
    * @returns {Promise<import("./Message").Message & { checklist: import("../checklist/Checklist").Checklist }>} - On success, the edited Message is returned.
    */

--- a/src/structures/misc/User.js
+++ b/src/structures/misc/User.js
@@ -2,10 +2,6 @@
 const { Base } = require("../Base");
 
 /**
- * @typedef {import("../../client/interfaces/Language").LanguageCode} LanguageCode
- */
-
-/**
  * @typedef {import("../../types").MethodParameters} MethodParameters
  */
 
@@ -55,7 +51,7 @@ class User extends Base {
     if ("language_code" in data) {
       /**
        * IETF language tag of the user's language
-       * @type {LanguageCode | undefined}
+       * @type {string | undefined}
        */
       this.language = data.language_code;
     }

--- a/src/util/permission/ApiPermissions.ts
+++ b/src/util/permission/ApiPermissions.ts
@@ -25,6 +25,9 @@ const ApiPermissionsFlags = {
   editStories: "can_edit_stories",
   deleteStories: "can_delete_stories",
   manageTopics: "can_manage_topics",
+  manageTags: "can_manage_tags",
+  editTag: "can_edit_tag",
+  manageDirectMessages: "can_manage_direct_messages",
 } as const;
 
 /**

--- a/src/util/permission/ChatPermissions.ts
+++ b/src/util/permission/ChatPermissions.ts
@@ -3,6 +3,7 @@
  */
 type ChatPermissionString =
   | "isAnonymous"
+  | "editTag"
   | "sendMessages"
   | "sendAudios"
   | "sendDocuments"
@@ -17,6 +18,7 @@ type ChatPermissionString =
   | "inviteUsers"
   | "pinMessages"
   | "manageTopics"
+  | "manageTags"
   | "manageDirectMessages";
 
 /**
@@ -24,6 +26,7 @@ type ChatPermissionString =
  */
 interface ChatPermissionFlags {
   isAnonymous?: boolean;
+  editTag?: boolean;
   sendMessages?: boolean;
   sendAudios?: boolean;
   sendDocuments?: boolean;
@@ -38,6 +41,7 @@ interface ChatPermissionFlags {
   inviteUsers?: boolean;
   pinMessages?: boolean;
   manageTopics?: boolean;
+  manageTags?: boolean;
   manageDirectMessages?: boolean;
 }
 
@@ -194,8 +198,10 @@ class ChatPermissions {
     inviteUsers: 12,
     pinMessages: 13,
     manageTopics: 14,
-    manageDirectMessages: 15,
-    isAnonymous: 16,
+    manageTags: 15,
+    manageDirectMessages: 16,
+    isAnonymous: 17,
+    editTag: 18,
   };
 }
 

--- a/src/util/permission/UserPermissions.ts
+++ b/src/util/permission/UserPermissions.ts
@@ -16,6 +16,7 @@ type UserPermissionString =
   | "editMessages"
   | "pinMessages"
   | "manageTopics"
+  | "manageTags"
   | "manageDirectMessages";
 
 /**
@@ -36,6 +37,7 @@ interface UserPermissionFlags {
   editMessages?: boolean;
   pinMessages?: boolean;
   manageTopics?: boolean;
+  manageTags?: boolean;
   manageDirectMessages?: boolean;
 }
 
@@ -192,7 +194,8 @@ class UserPermissions {
     editMessages: 12,
     pinMessages: 13,
     manageTopics: 14,
-    manageDirectMessages: 15,
+    manageTags: 15,
+    manageDirectMessages: 16,
   };
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -93,6 +93,7 @@ import {
  */
 export type ChatPermissionString =
   | "isAnonymous"
+  | "editTag"
   | "sendMessages"
   | "sendAudios"
   | "sendDocuments"
@@ -107,6 +108,7 @@ export type ChatPermissionString =
   | "inviteUsers"
   | "pinMessages"
   | "manageTopics"
+  | "manageTags"
   | "manageDirectMessages";
 
 /**
@@ -114,6 +116,7 @@ export type ChatPermissionString =
  */
 export interface ChatPermissionFlags {
   isAnonymous?: boolean;
+  editTag?: boolean;
   sendMessages?: boolean;
   sendAudios?: boolean;
   sendDocuments?: boolean;
@@ -128,6 +131,7 @@ export interface ChatPermissionFlags {
   inviteUsers?: boolean;
   pinMessages?: boolean;
   manageTopics?: boolean;
+  manageTags?: boolean;
   manageDirectMessages?: boolean;
 }
 
@@ -544,7 +548,7 @@ export declare class User extends Base {
   /**
    * IETF language tag of the user's language
    */
-  language?: LanguageCode;
+  language?: string;
   /**
    * True, if this user is a Telegram Premium user
    */
@@ -940,6 +944,7 @@ export type UserPermissionString =
   | "editMessages"
   | "pinMessages"
   | "manageTopics"
+  | "manageTags"
   | "manageDirectMessages";
 
 /**
@@ -960,6 +965,7 @@ export interface UserPermissionFlags {
   editMessages?: boolean;
   pinMessages?: boolean;
   manageTopics?: boolean;
+  manageTags?: boolean;
   manageDirectMessages?: boolean;
 }
 
@@ -1563,7 +1569,13 @@ export declare class MessageEntities extends Base {
   get customEmoji(): ReadonlyCollection<
     number,
     SearchResult & { customEmojiId: string }
-  >; /**
+  >;
+  /**
+   * Retrieves all date_time entities from the message.
+   * @returns A collection of date_time entities.
+   */
+  get dateTime(): ReadonlyCollection<number, SearchResult>;
+  /**
    * Searches for a specific type of entity in the message.
    * @param searchType - The type of entity to search for.
    * @returns A collection of found entities.
@@ -1587,7 +1599,8 @@ export declare class MessageEntities extends Base {
       | "pre"
       | "text_link"
       | "text_mention"
-      | "custom_emoji",
+      | "custom_emoji"
+      | "date_time",
   ): ReadonlyCollection<
     number,
     SearchResult &
@@ -1618,7 +1631,8 @@ export declare class MessageEntities extends Base {
         | "strikethrough"
         | "spoiler"
         | "blockquote"
-        | "code";
+        | "code"
+        | "dateTime";
     } & (
         | { type: "pre"; language?: LanguageCode }
         | { type: "textLink"; url: string }
@@ -6448,6 +6462,10 @@ export declare class Message extends Base {
    */
   senderBusinessBot?: User;
   /**
+   * For messages in channels and replies to channel messages in supergroups, the tag of the message sender
+   */
+  senderTag?: string;
+  /**
    * Information about the original message for forwarded messages
    */
   forwardOrigin?: MessageOrigin;
@@ -8941,6 +8959,10 @@ export declare class ChatMember extends Base {
    */
   nickName?: string;
   /**
+   * Custom tag for this member
+   */
+  tag?: string;
+  /**
    * True, if the user is a member of the chat at the moment of the request
    */
   isMember?: boolean;
@@ -9040,6 +9062,12 @@ export declare class ChatMember extends Base {
    * @returns Returns True on success.
    */
   setNikeName(name: string): Promise<true>;
+  /**
+   * Use this method to set a custom tag for a member of a supergroup.
+   * @param tag - New tag for the member; 0-32 characters
+   * @returns Returns True on success.
+   */
+  setTag(tag?: string): Promise<true>;
   /**
    * Checks if this member is equal to another member.
    * @param other - The other object to compare with.
@@ -10310,6 +10338,10 @@ export declare class BaseClient extends EventEmitter {
   setChatAdministratorCustomTitle(
     params: MethodParameters["setChatAdministratorCustomTitle"],
   ): Promise<MethodsLibReturnType["setChatAdministratorCustomTitle"]>;
+  /** Use this method to set a custom tag for a member of a supergroup. Returns True on success. */
+  setChatMemberTag(
+    params: MethodParameters["setChatMemberTag"],
+  ): Promise<MethodsLibReturnType["setChatMemberTag"]>;
   /** Use this method to ban a channel chat in a supergroup or a channel. Until the chat is unbanned, the owner of the banned chat won't be able to send messages on behalf of any of their channels. The bot must be an administrator in the supergroup or channel for this to work and must have the appropriate administrator rights. Returns True on success. */
   banChatSenderChat(
     chatId: number | string,

--- a/typings/telegram/Message.d.ts
+++ b/typings/telegram/Message.d.ts
@@ -13,7 +13,7 @@ export interface User {
   /** User's or bot's username */
   username?: string;
   /** IETF language tag of the user's language */
-  language_code?: LanguageCode;
+  language_code?: string;
   /** True, if this user is a Telegram Premium user */
   is_premium?: true;
   /** True, if this user added the bot to the attachment menu */
@@ -36,7 +36,7 @@ export interface LinkPreviewOptions {
 
 export declare namespace MessageEntity {
   interface AbstractMessageEntity {
-    /** Type of the entity. Currently, can be “mention” (@username), “hashtag” (#hashtag), “cashtag” ($USD), “bot_command” (/start@jobs_bot), “url” (https://telegram.org), “email” (do-not-reply@telegram.org), “phone_number” (+1-212-555-0123), “bold” (bold text), “italic” (italic text), “underline” (underlined text), “strikethrough” (strikethrough text), “spoiler” (spoiler message), “blockquote” (block quotation), “expandable_blockquote” (collapsed-by-default block quotation), “code” (monowidth string), “pre” (monowidth block), “text_link” (for clickable text URLs), “text_mention” (for users without usernames), “custom_emoji” (for inline custom emoji stickers) */
+    /** Type of the entity. Currently, can be “mention” (@username), “hashtag” (#hashtag), “cashtag” ($USD), “bot_command” (/start@jobs_bot), “url” (https://telegram.org), “email” (do-not-reply@telegram.org), “phone_number” (+1-212-555-0123), “bold” (bold text), “italic” (italic text), “underline” (underlined text), “strikethrough” (strikethrough text), “spoiler” (spoiler message), “blockquote” (block quotation), “expandable_blockquote” (collapsed-by-default block quotation), “code” (monowidth string), “pre” (monowidth block), “text_link” (for clickable text URLs), “text_mention” (for users without usernames), “custom_emoji” (for inline custom emoji stickers), “date_time” (for a formatted date and time) */
     type: string;
     /** Offset in UTF-16 code units to the start of the entity */
     offset: number;
@@ -59,7 +59,8 @@ export declare namespace MessageEntity {
       | "spoiler"
       | "blockquote"
       | "expandable_blockquote"
-      | "code";
+      | "code"
+      | "date_time";
   }
   export interface PreMessageEntity extends AbstractMessageEntity {
     type: "pre";

--- a/typings/telegram/Methods.d.ts
+++ b/typings/telegram/Methods.d.ts
@@ -1194,6 +1194,15 @@ export type ApiMethods = {
     /** New custom title for the administrator; 0-16 characters, emoji are not allowed */
     customTitle: string;
   }): true;
+  /** Use this method to set a custom tag for a member of a supergroup. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Returns True on success. */
+  setChatMemberTag(args: {
+    /** Unique identifier for the target supergroup (in the format @supergroupusername) */
+    chatId: number | string;
+    /** Unique identifier of the target user */
+    userId: string | number;
+    /** New tag for the member; 0-32 characters */
+    tag?: string;
+  }): true;
 
   /** Use this method to ban a channel chat in a supergroup or a channel. Until the chat is unbanned, the owner of the banned chat won't be able to send messages on behalf of any of their channels. The bot must be an administrator in the supergroup or channel for this to work and must have the appropriate administrator rights. Returns True on success. */
   banChatSenderChat(args: {


### PR DESCRIPTION
### Motivation
- Expose new Telegram features for member tags and date_time message entities and add missing permission flags so the library can parse and manage these API fields.
- Keep runtime structures and TypeScript typings consistent with API changes so callers can use new fields and methods safely.

### Description
- Added `setChatMemberTag` to `BaseClient` and the corresponding declaration in `Methods` to allow setting a custom tag for a supergroup member via the API (`setChatMemberTag`).
- Extended `ChatMember` with a `tag` property, `setTag` instance method, and equality check to include the tag; updated `Message` to expose `senderTag` for channel/reply senders.
- Added support for the `date_time` message entity in `MessageEntities` with `dateTime` getter, updated search/iterator types and message entity type lists.
- Introduced new permission flags and mappings: `manageTags` and `editTag` (and adjusted index ordering) in `ChatPermissions`, `UserPermissions`, and `ApiPermissions` and updated `toApiFormat` mapping.
- Updated user language typing from `LanguageCode` to `string` in runtime `User` and in `.d.ts` interfaces to match API behavior.
- Updated various runtime files and `.d.ts` typings (`typings/index.d.ts`, `typings/telegram/*.d.ts`) to reflect all new fields, methods, and types.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e29c756ad4832bbbfd9d06147dab0c)